### PR TITLE
Remove QUCC class

### DIFF
--- a/code/1_data-prep/4_prep-training-crowns/1_prep-training-cowns.R
+++ b/code/1_data-prep/4_prep-training-crowns/1_prep-training-cowns.R
@@ -14,7 +14,7 @@ crowns = st_read(PREDICTED_TREECROWNS_W_FIELD_DATA_FILE)
 
 # merge species that are functionally the same, and drop species that are very rare
 crowns = crowns |>
-  filter(!(species_observed %in% c("QUEV"))) |>
+  filter(!(species_observed %in% c("QUEV", "QUCC"))) |>
   mutate(species_observed = recode(species_observed,
                                    "PIPO" = "PIPJ",
                                    "PIJE" = "PIPJ")) |>


### PR DESCRIPTION
There was one entry for the QUCC class. I just wanted to check and make sure this didn't indicate a bigger error. Also, is this the recommended approach in R to do it? It appears to have worked and I saved the data out with a trailing `_david`. I can overwrite the current files if you confirm this is correct.